### PR TITLE
Update asmdefs settings to support older Unity versions

### DIFF
--- a/Documentation/Examples/OneLine.Examples.asmdef
+++ b/Documentation/Examples/OneLine.Examples.asmdef
@@ -1,10 +1,9 @@
 {
     "name": "OneLine.Examples",
     "references": [
-        "GUID:48490628f29f5a745823c646508b1c74",
-        "GUID:7a0017bf928d9644fa38a04cabefce63"
+        "st.one-line.Editor",
+        "st.one-line.Runtime"
     ],
-    "optionalUnityReferences": [],
     "includePlatforms": [
         "Editor"
     ],
@@ -12,7 +11,7 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": true,
+    "autoReferenced": false,
     "defineConstraints": [],
     "versionDefines": []
 }

--- a/Editor/OneLine.Editor.asmdef
+++ b/Editor/OneLine.Editor.asmdef
@@ -1,10 +1,9 @@
 {
     "name": "st.one-line.Editor",
     "references": [
-        "GUID:73c70a6eb6b6f444c878926f743350f6",
-        "GUID:7a0017bf928d9644fa38a04cabefce63"
+        "st.rect-ex.Runtime",
+        "st.one-line.Runtime"
     ],
-    "optionalUnityReferences": [],
     "includePlatforms": [
         "Editor"
     ],
@@ -12,7 +11,7 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": true,
+    "autoReferenced": false,
     "defineConstraints": [],
     "versionDefines": []
 }

--- a/Runtime/OneLine.Runtime.asmdef
+++ b/Runtime/OneLine.Runtime.asmdef
@@ -1,6 +1,14 @@
-﻿{
-  "name": "st.one-line.Runtime",
-  "references": [
-    "GUID:73c70a6eb6b6f444c878926f743350f6"
-  ]
+{
+    "name": "st.one-line.Runtime",
+    "references": [
+        "st.rect-ex.Runtime"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": false,
+    "defineConstraints": [],
+    "versionDefines": []
 }

--- a/Tests/Editor/OneLine.Tests.Editor.asmdef
+++ b/Tests/Editor/OneLine.Tests.Editor.asmdef
@@ -1,11 +1,10 @@
 {
     "name": "OneLine.Tests.Editor",
     "references": [
-        "GUID:7a0017bf928d9644fa38a04cabefce63",
-        "GUID:48490628f29f5a745823c646508b1c74",
-        "GUID:73c70a6eb6b6f444c878926f743350f6"
+        "st.one-line.Runtime",
+        "st.one-line.Editor",
+        "st.rect-ex.Runtime"
     ],
-    "optionalUnityReferences": [],
     "includePlatforms": [
         "Editor"
     ],
@@ -13,7 +12,7 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": true,
+    "autoReferenced": false,
     "defineConstraints": [],
     "versionDefines": []
 }


### PR DESCRIPTION
Fix for https://github.com/slavniyteo/one-line/issues/42

Tested on windows platform.

DOD:
1. start empty app with plugin without errors
2. no changes in *.asmdef after full reimport
3. oneline examples draws
4. editor tests passes for rect-ex

By version:
2017.4.1f1 - passed (manual installation, UPM not supported here) 
2018.2.9f1 - passed (UPM)
2018.3.11f1 - passed (UPM)
2018.4.5f1 - passed (UPM)
2019.2.0f1 - passed (UPM)

UPD:
2018.3.0f2 (Ubuntu) - passed (UPM)