### PR TITLE
🐛 reverted asmdef autoReference to true

### DIFF
--- a/Editor/OneLine.Editor.asmdef
+++ b/Editor/OneLine.Editor.asmdef
@@ -4,6 +4,7 @@
         "st.rect-ex.Runtime",
         "st.one-line.Runtime"
     ],
+    "optionalUnityReferences": [],
     "includePlatforms": [
         "Editor"
     ],
@@ -11,7 +12,6 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": false,
-    "defineConstraints": [],
-    "versionDefines": []
+    "autoReferenced": true,
+    "defineConstraints": []
 }

--- a/Runtime/OneLine.Runtime.asmdef
+++ b/Runtime/OneLine.Runtime.asmdef
@@ -3,12 +3,12 @@
     "references": [
         "st.rect-ex.Runtime"
     ],
+    "optionalUnityReferences": [],
     "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": false,
-    "defineConstraints": [],
-    "versionDefines": []
+    "autoReferenced": true,
+    "defineConstraints": []
 }


### PR DESCRIPTION
После предыдущего пулл-реквеста из-за выключенного флага autoReferenced стало невозможным использовать oneline из стандартных сборок юнити. То же касается и rectex, если кто-то захочет использовать его отдельно.